### PR TITLE
Removed dead links

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ A curated list of podcasts we like to listen to.
 * [Laravel News Podcast](https://laravel-news.com/podcast/) - The Laravel News Podcast brings you all the latest news and events related to Laravel.
 * [Linear Digressions](http://lineardigressions.com/) - Explores topics of data science and machine learning in an accessible way through real-world stories and examples.
 * [Linux Action News](https://www.jupiterbroadcasting.com/show/linux-action-news/) - Weekly news about Linux and the open source world.
-* Linux Headlines (https://linuxheadlines.show/ - site down) [iTunes](https://podcasts.apple.com/gb/podcast/linux-headlines/id1479487338) - Linux and open source headlines every weekday, in under 3 minutes.
 * [Linux For Everyone](https://linuxforeveryone.fireside.fm/) - A show about the thrilling world of desktop Linux, open source software and the community creating it. For beginners and veterans alike! Hosted by Forbes' Jason Evangelho and friends.
 * [Linux Unplugged](https://www.jupiterbroadcasting.com/show/linuxun/) - Weekly Linux live and open talk show
 * [Listen and Learn about AWS](https://aws.amazon.com/podcasts/aws-podcast/) - Jeff Barr discusses various aspects of the Amazon Web Services (AWS) offering. Each podcast include AWS news, tech tips, and interviews with startups, AWS partners, and AWS employees.
@@ -267,7 +266,6 @@ A curated list of podcasts we like to listen to.
 * [Souforce.cloud](https://souforce.cloud/podcast/) - O primeiro podcast voltado ao mundo Salesforce no idioma Português, aqui batemos um papo de Desenvolvimento, Administração da Plataforma, Produtos Salesforce além de assuntos como Carreira entre outros.
 * [Start Coding](https://anchor.fm/start-coding) - Start Coding é uma iniciativa online com o objetivo de inserir mulheres na tecnologia. O podcast apresenta temas da computação e a equidade de gênero na área.
 * [Tecnocast](https://tecnoblog.net/categoria/podcast/) - Podcast do Tecnoblog, sobre tecnologia.
-* Tecnologicamente Arretado (http://tecnologicamentearretado.com.br - site down) [RadioPublic](https://radiopublic.com/tecnologicamente-arretado-GMlKkQ) - Agilidade, arquitetura, linguagens e ativismo.
 * [Xadrez Verbal](https://xadrezverbal.com/category/audio/podcast-do-xadrez-verbal/) - Política, história e atualidades.
 * [Zeno Overflow](https://soundcloud.com/zenorocha) - Uma série de perguntas e respostas ao vivo sobre tecnologia, carreira e a vida fora do Brasil.
 * [Zone Of Front-Enders](https://zofe.com.br/) - Podcast com enfoque no desenvolvimento front-end da web.  
@@ -305,7 +303,6 @@ A curated list of podcasts we like to listen to.
   * [Linux Express, de Podcast Linux](https://podcastlinux.gitlab.io) - Resumen más personal de Podcast Linux.
 * [Podcast oficial KDE España](https://www.ivoox.com/podcast-podcast-kde-espana_sq_f1249423_1.html) - Podcast de la Asociación Cultural KDE España.
 * [Salmorejo Geek](https://www.ivoox.com/podcast-salmorejo-geek_sq_f1206500_1.html) - Batiburrillo Digital. Sobre todo Linux.
-* [Tomando Un Café](https://rooteando.com/tag/podcast) - Aplicaciones de Linux, programación y formación, aunque cualquier tema relacionado con la tecnología puede tener cabida.
 * [Ubuntu y otras hierbas](https://www.ubuntuleon.com/search?q=podcast&max-results=20&by-date=true) - Podcast en español sobre Ubuntu y software libre en general.
 * [uGeek](https://ugeek.github.io/) - Tecnología, Android, Linux, Servidores y mucho más...
 


### PR DESCRIPTION
  1. [L132] 404 podcasts.apple.com/gb/podcast/linux-headlines/id1479487338  
  2. [L132]  linuxheadlines.show Failed to open TCP connection to linuxheadlines.show:443 (getaddrinfo: Try again) 
  3. [L270]  http://tecnologicamentearretado.com.br Failed to open TCP connection to tecnologicamentearretado.com.br:80 (getaddrinfo: Name does not resolve) 
  4. [L308]  rooteando.com/tag/podcast SSL_connect returned=1 errno=0 state=error: certificate verify failed (unspecified certificate verification error)