### PR TITLE
Add 'PH Santos Podcast' and 'Olá, Gabs' Podcasts to the Portuguese Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ A curated list of podcasts we like to listen to.
 * [Xadrez Verbal](https://xadrezverbal.com/category/audio/podcast-do-xadrez-verbal/) - Política, história e atualidades.
 * [Zone Of Front-Enders](https://zofe.com.br/) - Podcast com enfoque no desenvolvimento front-end da web.
 * [Zeno Overflow](https://soundcloud.com/zenorocha) - Uma série de perguntas e respostas ao vivo sobre tecnologia, carreira e a vida fora do Brasil.
+* [PH Santos Podcast](https://open.spotify.com/show/08zI81PqsvRqnzPvBElIKZ?si=8ca629191f074b25) - Podcast do Comunicador e Crítico de Cinema PH Santos, focado em séries e filmes.
+* [Olá, Gabs](https://open.spotify.com/show/094hX276k5lFzM8Ig2xpsl?si=8e20c3b64c1a4ce7) - Podcast sobre tecnologia de maneira bem humana. Reflexõe, histórias e tecnologia.
 
 ## In Spanish
 


### PR DESCRIPTION
This PR adds two new podcasts to the "In Portuguese" section of the README.

- [PH Santos Podcast](https://open.spotify.com/show/08zI81PqsvRqnzPvBElIKZ?si=700c49489db74fa6) - Podcast do Comunicador e Crítico de Cinema PH Santos, focado em séries e filmes.
- [Olá, Gabs](https://open.spotify.com/show/094hX276k5lFzM8Ig2xpsl?si=b141d2768d444ebf) - Podcast sobre tecnologia de maneira bem humana. Reflexõe, histórias e tecnologia.

These additions provide more valuable content for Portuguese-speaking geeks and tech enthusiasts.
