### PR TITLE
Add The Podcast App to Tooling section

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ A curated list of podcasts we like to listen to.
 * [gPodder](https://gpodder.github.io) / [gPodder Director](https://gpodder.net/) - (Multi-plataform Open Source and Podcast Directory)
 * [RadioPublic](https://radiopublic.com/)
 * [Podcast Addict](https://podcastaddict.com/app) - Android Podcast player
+* [The Podcast App](https://thepodcastapp.dev) - Free, ad-free podcast player for iOS and Android with AI cross-episode search
 
 ### More
 


### PR DESCRIPTION
Adding The Podcast App to the Tooling section.

- Free podcast player for iOS and Android
- Zero ads, no subscription required for core player
- AI feature (Brain) for cross-episode search with source citations
- Video podcast support (YouTube native)
- OPML import from Spotify, Pocket Casts, Overcast

Website: https://thepodcastapp.dev
iOS: https://apps.apple.com/app/the-podcast-app/id6754806244
Android: https://play.google.com/store/apps/details?id=com.magnolia.thepodcastapp